### PR TITLE
Add topologyKey to keep kubectl happy

### DIFF
--- a/lab-13/README.md
+++ b/lab-13/README.md
@@ -132,6 +132,7 @@ spec:
             operator: In
             values:
             - test
+        topologyKey: failure-domain.beta.kubernetes.io/zone
   containers:
   - name: container-info
     image: gluobe/container-info:blue
@@ -163,6 +164,7 @@ spec:
             operator: In
             values:
             - test
+        topologyKey: failure-domain.beta.kubernetes.io/zone
   containers:
   - name: container-info
     image: gluobe/container-info:blue


### PR DESCRIPTION
Fixes

```
error: error validating "STDIN": error validating data: ValidationError(Pod.spec.affinity.podAffinity.requiredDuringSchedulingIgnoredDuringExecution[0]): missing required field "topologyKey" in io.k8s.api.core.v1.PodAffinityTerm; if you choose to ignore these errors, turn validation off with --validate=false
```